### PR TITLE
Feature/volume removal prompt

### DIFF
--- a/Models/DockerModels.cs
+++ b/Models/DockerModels.cs
@@ -11,7 +11,15 @@ public record ContainerInfo(
     DateTime Created,
     string Status,
     Dictionary<string, string> Labels,
-    List<PortMapping> Ports);
+    List<PortMapping> Ports,
+    List<VolumeMount>? Volumes = null);
+
+public record VolumeMount(
+    string Name,
+    string Source,
+    string Destination,
+    bool ReadWrite,
+    string Driver);
 
 public record struct PortMapping(
     string PrivatePort,

--- a/Services/DialogService.cs
+++ b/Services/DialogService.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using OrbitalDocking.Models;
 using OrbitalDocking.ViewModels;
 using OrbitalDocking.Views;
+using OrbitalDocking.Views.Dialogs;
 
 namespace OrbitalDocking.Services;
 
@@ -20,8 +24,31 @@ public class DialogService(Func<string, string, LogsViewModel> logsViewModelFact
     
     public async Task<bool> ShowConfirmationAsync(string title, string message, Window owner)
     {
-        // TODO return true, implement proper dialog later
-        await Task.CompletedTask;
-        return true;
+        var dialog = new ConfirmationDialog
+        {
+            Title = title,
+            Message = message
+        };
+        
+        var result = await dialog.ShowDialog<bool>(owner);
+        return result;
+    }
+    
+    public async Task<VolumeRemovalChoice> ShowVolumeRemovalDialogAsync(string containerName, List<VolumeMount> volumes, Window owner)
+    {
+        var namedVolumes = volumes
+            .Where(v => !string.IsNullOrEmpty(v.Name))
+            .Select(v => v.Name)
+            .Distinct()
+            .ToList();
+
+        var dialog = new VolumeRemovalDialog
+        {
+            ContainerName = containerName,
+            VolumeNames = namedVolumes
+        };
+        
+        var result = await dialog.ShowDialog<VolumeRemovalChoice>(owner);
+        return result;
     }
 }

--- a/Services/DockerMapper.cs
+++ b/Services/DockerMapper.cs
@@ -22,7 +22,8 @@ public class DockerMapper : IDockerMapper
                 p.PrivatePort.ToString(),
                 p.PublicPort.ToString(),
                 p.Type,
-                p.IP ?? string.Empty)).ToList() ?? new List<PortMapping>());
+                p.IP ?? string.Empty)).ToList() ?? new List<PortMapping>(),
+            Volumes: MapVolumeMounts(container.Mounts));
     }
 
     public ImageInfo MapToImageInfo(ImagesListResponse image)
@@ -49,7 +50,8 @@ public class DockerMapper : IDockerMapper
             Created: container.Created,
             Status: container.State.Status,
             Labels: container.Config.Labels?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value) ?? new Dictionary<string, string>(),
-            Ports: new List<PortMapping>());
+            Ports: new List<PortMapping>(),
+            Volumes: MapVolumeMounts(container.Mounts));
     }
 
     public VolumeInfo MapToVolumeInfo(VolumeResponse volume)
@@ -89,5 +91,18 @@ public class DockerMapper : IDockerMapper
             "removing" => Models.ContainerState.Removing,
             _ => Models.ContainerState.Exited
         };
+    }
+
+    private List<VolumeMount>? MapVolumeMounts(IList<MountPoint>? mounts)
+    {
+        if (mounts == null || mounts.Count == 0)
+            return null;
+
+        return mounts.Select(m => new VolumeMount(
+            Name: m.Name ?? string.Empty,
+            Source: m.Source ?? string.Empty,
+            Destination: m.Destination ?? string.Empty,
+            ReadWrite: !m.Mode?.Contains("ro") ?? true,
+            Driver: m.Driver ?? string.Empty)).ToList();
     }
 }

--- a/Services/DockerMapper.cs
+++ b/Services/DockerMapper.cs
@@ -102,7 +102,17 @@ public class DockerMapper : IDockerMapper
             Name: m.Name ?? string.Empty,
             Source: m.Source ?? string.Empty,
             Destination: m.Destination ?? string.Empty,
-            ReadWrite: !m.Mode?.Contains("ro") ?? true,
+            ReadWrite: IsReadWrite(m.Mode),
             Driver: m.Driver ?? string.Empty)).ToList();
+    }
+    
+    private static bool IsReadWrite(string? mode)
+    {
+        // If mode is null or empty, default to read-write
+        if (string.IsNullOrEmpty(mode))
+            return true;
+            
+        // Check if mode contains "ro" (read-only)
+        return !mode.Contains("ro", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Services/IDialogService.cs
+++ b/Services/IDialogService.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using OrbitalDocking.Models;
 
 namespace OrbitalDocking.Services;
 
@@ -7,4 +9,12 @@ public interface IDialogService
 {
     void ShowLogsWindow(string containerId, string containerName, Window owner);
     Task<bool> ShowConfirmationAsync(string title, string message, Window owner);
+    Task<VolumeRemovalChoice> ShowVolumeRemovalDialogAsync(string containerName, List<VolumeMount> volumes, Window owner);
+}
+
+public enum VolumeRemovalChoice
+{
+    Cancel,
+    RemoveContainerOnly,
+    RemoveContainerAndVolumes
 }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -359,6 +359,20 @@ public partial class MainWindowViewModel : ViewModelBase
 
         var containerInfo = containerInfoResult.Value;
         
+        // Debug: Log volume information
+        if (containerInfo.Volumes != null)
+        {
+            _logger.LogInformation("Container {Name} has {Count} volumes", container.Name, containerInfo.Volumes.Count);
+            foreach (var vol in containerInfo.Volumes)
+            {
+                _logger.LogInformation("Volume: Name={Name}, Source={Source}, Dest={Dest}", vol.Name, vol.Source, vol.Destination);
+            }
+        }
+        else
+        {
+            _logger.LogInformation("Container {Name} has null Volumes", container.Name);
+        }
+        
         // Check if container has named volumes (not bind mounts)
         var namedVolumes = containerInfo.Volumes?
             .Where(v => !string.IsNullOrEmpty(v.Name))

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -359,20 +359,6 @@ public partial class MainWindowViewModel : ViewModelBase
 
         var containerInfo = containerInfoResult.Value;
         
-        // Debug: Log volume information
-        if (containerInfo.Volumes != null)
-        {
-            _logger.LogInformation("Container {Name} has {Count} volumes", container.Name, containerInfo.Volumes.Count);
-            foreach (var vol in containerInfo.Volumes)
-            {
-                _logger.LogInformation("Volume: Name={Name}, Source={Source}, Dest={Dest}", vol.Name, vol.Source, vol.Destination);
-            }
-        }
-        else
-        {
-            _logger.LogInformation("Container {Name} has null Volumes", container.Name);
-        }
-        
         // Check if container has named volumes (not bind mounts)
         var namedVolumes = containerInfo.Volumes?
             .Where(v => !string.IsNullOrEmpty(v.Name))

--- a/Views/Dialogs/ConfirmationDialog.axaml
+++ b/Views/Dialogs/ConfirmationDialog.axaml
@@ -1,0 +1,35 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:OrbitalDocking.Views.Dialogs"
+        x:Class="OrbitalDocking.Views.Dialogs.ConfirmationDialog"
+        x:DataType="dialogs:ConfirmationDialog"
+        Title="Confirmation"
+        Width="400"
+        Height="200"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False">
+    <Grid Margin="20" RowDefinitions="*, Auto">
+        <TextBlock Grid.Row="0" 
+                   Name="MessageTextBlock"
+                   Text="{Binding Message}" 
+                   TextWrapping="Wrap"
+                   VerticalAlignment="Center"
+                   HorizontalAlignment="Center"/>
+        
+        <StackPanel Grid.Row="1" 
+                    Orientation="Horizontal" 
+                    HorizontalAlignment="Right"
+                    Spacing="10"
+                    Margin="0,20,0,0">
+            <Button Name="CancelButton" 
+                    Content="Cancel" 
+                    Width="80"
+                    Click="OnCancelClick"/>
+            <Button Name="ConfirmButton" 
+                    Content="Yes" 
+                    Width="80"
+                    Classes="accent"
+                    Click="OnConfirmClick"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Views/Dialogs/ConfirmationDialog.axaml
+++ b/Views/Dialogs/ConfirmationDialog.axaml
@@ -4,32 +4,56 @@
         x:Class="OrbitalDocking.Views.Dialogs.ConfirmationDialog"
         x:DataType="dialogs:ConfirmationDialog"
         Title="Confirmation"
-        Width="400"
-        Height="200"
+        Width="420"
+        SizeToContent="Height"
+        MinHeight="180"
         WindowStartupLocation="CenterOwner"
-        CanResize="False">
-    <Grid Margin="20" RowDefinitions="*, Auto">
-        <TextBlock Grid.Row="0" 
-                   Name="MessageTextBlock"
-                   Text="{Binding Message}" 
-                   TextWrapping="Wrap"
-                   VerticalAlignment="Center"
-                   HorizontalAlignment="Center"/>
-        
-        <StackPanel Grid.Row="1" 
-                    Orientation="Horizontal" 
-                    HorizontalAlignment="Right"
-                    Spacing="10"
-                    Margin="0,20,0,0">
-            <Button Name="CancelButton" 
-                    Content="Cancel" 
-                    Width="80"
-                    Click="OnCancelClick"/>
-            <Button Name="ConfirmButton" 
-                    Content="Yes" 
-                    Width="80"
-                    Classes="accent"
-                    Click="OnConfirmClick"/>
-        </StackPanel>
-    </Grid>
+        CanResize="False"
+        Background="{DynamicResource SystemRegionBrush}">
+    <Border Classes="dialog-content">
+        <Grid Margin="24" RowDefinitions="*,Auto">
+            <TextBlock Grid.Row="0" 
+                       Name="MessageTextBlock"
+                       Text="{Binding Message}" 
+                       TextWrapping="Wrap"
+                       VerticalAlignment="Center"
+                       HorizontalAlignment="Center"
+                       TextAlignment="Center"
+                       FontSize="14"
+                       Margin="0,20,0,20"/>
+            
+            <StackPanel Grid.Row="1" 
+                        Orientation="Horizontal" 
+                        HorizontalAlignment="Right"
+                        Spacing="12"
+                        Margin="0,20,0,0">
+                <Button Name="CancelButton" 
+                        Content="Cancel" 
+                        MinWidth="90"
+                        Height="32"
+                        Click="OnCancelClick"/>
+                <Button Name="ConfirmButton" 
+                        Content="Yes" 
+                        MinWidth="90"
+                        Height="32"
+                        Classes="accent"
+                        Click="OnConfirmClick"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+    
+    <Window.Styles>
+        <Style Selector="Button">
+            <Setter Property="CornerRadius" Value="4"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.accent">
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <Style Selector="Button.accent:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColorDark1}"/>
+        </Style>
+    </Window.Styles>
 </Window>

--- a/Views/Dialogs/ConfirmationDialog.axaml.cs
+++ b/Views/Dialogs/ConfirmationDialog.axaml.cs
@@ -1,0 +1,25 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace OrbitalDocking.Views.Dialogs;
+
+public partial class ConfirmationDialog : Window
+{
+    public string Message { get; set; } = string.Empty;
+    
+    public ConfirmationDialog()
+    {
+        InitializeComponent();
+        DataContext = this;
+    }
+    
+    private void OnConfirmClick(object? sender, RoutedEventArgs e)
+    {
+        Close(true);
+    }
+    
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Close(false);
+    }
+}

--- a/Views/Dialogs/VolumeRemovalDialog.axaml
+++ b/Views/Dialogs/VolumeRemovalDialog.axaml
@@ -4,64 +4,103 @@
         x:Class="OrbitalDocking.Views.Dialogs.VolumeRemovalDialog"
         x:DataType="dialogs:VolumeRemovalDialog"
         Title="Container Has Volumes"
-        Width="500"
-        Height="350"
+        Width="650"
+        SizeToContent="Height"
+        MinHeight="250"
+        MaxHeight="500"
         WindowStartupLocation="CenterOwner"
-        CanResize="False">
-    <Grid Margin="20" RowDefinitions="Auto,*,Auto">
-        <TextBlock Grid.Row="0" 
-                   FontWeight="Bold"
-                   FontSize="14"
-                   Margin="0,0,0,10">
-            <TextBlock.Text>
-                <MultiBinding StringFormat="Container '{0}' has the following named volumes:">
-                    <Binding Path="ContainerName"/>
-                </MultiBinding>
-            </TextBlock.Text>
-        </TextBlock>
-        
-        <ScrollViewer Grid.Row="1" 
-                      VerticalScrollBarVisibility="Auto"
-                      Margin="0,10">
-            <ItemsControl ItemsSource="{Binding VolumeNames}">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Margin="20,2">
-                            <TextBlock.Text>
-                                <MultiBinding StringFormat="• {0}">
-                                    <Binding/>
-                                </MultiBinding>
-                            </TextBlock.Text>
-                        </TextBlock>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </ScrollViewer>
-        
-        <Grid Grid.Row="2" RowDefinitions="Auto,Auto">
-            <TextBlock Grid.Row="0" 
-                       Text="What would you like to do?"
-                       Margin="0,10,0,20"
-                       HorizontalAlignment="Center"/>
+        CanResize="False"
+        Background="{DynamicResource SystemRegionBrush}">
+    <Border Classes="dialog-content">
+        <Grid Margin="24" RowDefinitions="Auto,Auto,*,Auto">
+            <!-- Header Section -->
+            <StackPanel Grid.Row="0" Spacing="8">
+                <TextBlock FontSize="16" 
+                           FontWeight="SemiBold"
+                           TextWrapping="Wrap">
+                    <TextBlock.Text>
+                        <MultiBinding StringFormat="Container '{0}' has the following named volumes:">
+                            <Binding Path="ContainerName"/>
+                        </MultiBinding>
+                    </TextBlock.Text>
+                </TextBlock>
+            </StackPanel>
             
-            <StackPanel Grid.Row="1" 
-                        Orientation="Horizontal" 
-                        HorizontalAlignment="Center"
-                        Spacing="10">
-                <Button Name="CancelButton" 
-                        Content="Cancel" 
-                        Width="120"
-                        Click="OnCancelClick"/>
-                <Button Name="ContainerOnlyButton" 
-                        Content="Remove Container Only" 
-                        Width="160"
-                        Click="OnContainerOnlyClick"/>
-                <Button Name="ContainerAndVolumesButton" 
-                        Content="Remove Container and Volumes" 
-                        Width="200"
-                        Classes="accent"
-                        Click="OnContainerAndVolumesClick"/>
+            <!-- Volumes List -->
+            <Border Grid.Row="2" 
+                    Margin="0,16,0,0"
+                    Background="{DynamicResource SystemAltHighColor}"
+                    CornerRadius="8"
+                    BorderBrush="{DynamicResource SystemBaseLowColor}"
+                    BorderThickness="1"
+                    MinHeight="60"
+                    MaxHeight="200">
+                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                              Padding="16,12">
+                    <ItemsControl ItemsSource="{Binding VolumeNames}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal" Margin="0,2">
+                                    <TextBlock Text="•" 
+                                               Margin="0,0,8,0"
+                                               Foreground="{DynamicResource SystemAccentColor}"/>
+                                    <TextBlock Text="{Binding}"
+                                               FontFamily="Cascadia Code, Consolas, monospace"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Border>
+            
+            <!-- Action Section -->
+            <StackPanel Grid.Row="3" 
+                        Margin="0,24,0,0"
+                        Spacing="16">
+                <TextBlock Text="What would you like to do?"
+                           HorizontalAlignment="Center"
+                           FontSize="14"
+                           Opacity="0.8"/>
+                
+                <StackPanel Orientation="Horizontal" 
+                            HorizontalAlignment="Center"
+                            Spacing="12">
+                    <Button Name="CancelButton" 
+                            Content="Cancel" 
+                            MinWidth="100"
+                            Height="36"
+                            Padding="16,8"
+                            Click="OnCancelClick"/>
+                    <Button Name="ContainerOnlyButton" 
+                            Content="Container Only" 
+                            MinWidth="140"
+                            Height="36"
+                            Padding="16,8"
+                            Click="OnContainerOnlyClick"/>
+                    <Button Name="ContainerAndVolumesButton" 
+                            Content="Container + Volumes" 
+                            MinWidth="180"
+                            Height="36"
+                            Padding="16,8"
+                            Classes="accent"
+                            Click="OnContainerAndVolumesClick"/>
+                </StackPanel>
             </StackPanel>
         </Grid>
-    </Grid>
+    </Border>
+    
+    <Window.Styles>
+        <Style Selector="Button">
+            <Setter Property="CornerRadius" Value="4"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.accent">
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <Style Selector="Button.accent:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColorDark1}"/>
+        </Style>
+    </Window.Styles>
 </Window>

--- a/Views/Dialogs/VolumeRemovalDialog.axaml
+++ b/Views/Dialogs/VolumeRemovalDialog.axaml
@@ -1,0 +1,67 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:OrbitalDocking.Views.Dialogs"
+        x:Class="OrbitalDocking.Views.Dialogs.VolumeRemovalDialog"
+        x:DataType="dialogs:VolumeRemovalDialog"
+        Title="Container Has Volumes"
+        Width="500"
+        Height="350"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False">
+    <Grid Margin="20" RowDefinitions="Auto,*,Auto">
+        <TextBlock Grid.Row="0" 
+                   FontWeight="Bold"
+                   FontSize="14"
+                   Margin="0,0,0,10">
+            <TextBlock.Text>
+                <MultiBinding StringFormat="Container '{0}' has the following named volumes:">
+                    <Binding Path="ContainerName"/>
+                </MultiBinding>
+            </TextBlock.Text>
+        </TextBlock>
+        
+        <ScrollViewer Grid.Row="1" 
+                      VerticalScrollBarVisibility="Auto"
+                      Margin="0,10">
+            <ItemsControl ItemsSource="{Binding VolumeNames}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Margin="20,2">
+                            <TextBlock.Text>
+                                <MultiBinding StringFormat="• {0}">
+                                    <Binding/>
+                                </MultiBinding>
+                            </TextBlock.Text>
+                        </TextBlock>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+        
+        <Grid Grid.Row="2" RowDefinitions="Auto,Auto">
+            <TextBlock Grid.Row="0" 
+                       Text="What would you like to do?"
+                       Margin="0,10,0,20"
+                       HorizontalAlignment="Center"/>
+            
+            <StackPanel Grid.Row="1" 
+                        Orientation="Horizontal" 
+                        HorizontalAlignment="Center"
+                        Spacing="10">
+                <Button Name="CancelButton" 
+                        Content="Cancel" 
+                        Width="120"
+                        Click="OnCancelClick"/>
+                <Button Name="ContainerOnlyButton" 
+                        Content="Remove Container Only" 
+                        Width="160"
+                        Click="OnContainerOnlyClick"/>
+                <Button Name="ContainerAndVolumesButton" 
+                        Content="Remove Container and Volumes" 
+                        Width="200"
+                        Classes="accent"
+                        Click="OnContainerAndVolumesClick"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Window>

--- a/Views/Dialogs/VolumeRemovalDialog.axaml.cs
+++ b/Views/Dialogs/VolumeRemovalDialog.axaml.cs
@@ -38,7 +38,7 @@ public partial class VolumeRemovalDialog : Window, INotifyPropertyChanged
         DataContext = this;
     }
     
-    public event PropertyChangedEventHandler? PropertyChanged;
+    public new event PropertyChangedEventHandler? PropertyChanged;
     
     protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {

--- a/Views/Dialogs/VolumeRemovalDialog.axaml.cs
+++ b/Views/Dialogs/VolumeRemovalDialog.axaml.cs
@@ -38,7 +38,7 @@ public partial class VolumeRemovalDialog : Window, INotifyPropertyChanged
         DataContext = this;
     }
     
-    public new event PropertyChangedEventHandler? PropertyChanged;
+    public event PropertyChangedEventHandler? PropertyChanged;
     
     protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {

--- a/Views/Dialogs/VolumeRemovalDialog.axaml.cs
+++ b/Views/Dialogs/VolumeRemovalDialog.axaml.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using OrbitalDocking.Services;
+
+namespace OrbitalDocking.Views.Dialogs;
+
+public partial class VolumeRemovalDialog : Window
+{
+    public string ContainerName { get; set; } = string.Empty;
+    public List<string> VolumeNames { get; set; } = new();
+    
+    public VolumeRemovalDialog()
+    {
+        InitializeComponent();
+        DataContext = this;
+    }
+    
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Close(VolumeRemovalChoice.Cancel);
+    }
+    
+    private void OnContainerOnlyClick(object? sender, RoutedEventArgs e)
+    {
+        Close(VolumeRemovalChoice.RemoveContainerOnly);
+    }
+    
+    private void OnContainerAndVolumesClick(object? sender, RoutedEventArgs e)
+    {
+        Close(VolumeRemovalChoice.RemoveContainerAndVolumes);
+    }
+}

--- a/Views/Dialogs/VolumeRemovalDialog.axaml.cs
+++ b/Views/Dialogs/VolumeRemovalDialog.axaml.cs
@@ -1,19 +1,48 @@
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using OrbitalDocking.Services;
 
 namespace OrbitalDocking.Views.Dialogs;
 
-public partial class VolumeRemovalDialog : Window
+public partial class VolumeRemovalDialog : Window, INotifyPropertyChanged
 {
-    public string ContainerName { get; set; } = string.Empty;
-    public List<string> VolumeNames { get; set; } = new();
+    private string _containerName = string.Empty;
+    private List<string> _volumeNames = new();
+    
+    public string ContainerName 
+    { 
+        get => _containerName;
+        set
+        {
+            _containerName = value;
+            OnPropertyChanged();
+        }
+    }
+    
+    public List<string> VolumeNames 
+    { 
+        get => _volumeNames;
+        set
+        {
+            _volumeNames = value;
+            OnPropertyChanged();
+        }
+    }
     
     public VolumeRemovalDialog()
     {
         InitializeComponent();
         DataContext = this;
+    }
+    
+    public new event PropertyChangedEventHandler? PropertyChanged;
+    
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
     
     private void OnCancelClick(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
This pull request introduces a new feature that allows users to choose whether to remove Docker containers only or remove both containers and their associated named volumes. It adds user interface dialogs for confirmation and volume removal, updates the model and service layers to support volume information, and refactors container and stack removal logic to prompt users appropriately and handle volume deletions.

### User Interface Enhancements

* Added `ConfirmationDialog` and `VolumeRemovalDialog` windows, including their code-behind files, to prompt users for confirmation and provide options when removing containers or stacks with named volumes. [[1]](diffhunk://#diff-6f41b72b25d2eac342f31fc29c9cbc42eb142ebb057b91ddd53f36cc49212e9cR1-R59) [[2]](diffhunk://#diff-41c132ec87d11b061a4de9ac8d5ca3f61ee3285d41fac86d57643f12db8d3bc0R1-R25) [[3]](diffhunk://#diff-7ba353ed457decc260b41487ecd4ea266b2e52eddc179df9f9269f5d746a33faR1-R106) [[4]](diffhunk://#diff-35f8d6606426dc4a4c341fe078ffa329978027384de73dcc3a40806eb6129b85R1-R62)
* Updated `DialogService` to support showing these dialogs and returning the user's choice. [[1]](diffhunk://#diff-e4500f80c189b269f71067d90ed1e190f5a697488ac210ecac30040e0f112094L23-R52) [[2]](diffhunk://#diff-e4500f80c189b269f71067d90ed1e190f5a697488ac210ecac30040e0f112094R2-R9) [[3]](diffhunk://#diff-dbd55c205117c319db66a759e774ee5e1d118cbfd6317b7572721c14e445b01eR1-R19)

### Model and Data Layer Updates

* Extended the `ContainerInfo` record to include a list of `VolumeMount` objects, with a new `VolumeMount` record to represent volume details.
* Updated `DockerMapper` to map Docker API mount points to the new `VolumeMount` model and include them when constructing `ContainerInfo`. [[1]](diffhunk://#diff-fbd4bf6b6dd240d25fb67d5935c58a15eeda17c484051c532372ae95c376737dL25-R26) [[2]](diffhunk://#diff-fbd4bf6b6dd240d25fb67d5935c58a15eeda17c484051c532372ae95c376737dL52-R54) [[3]](diffhunk://#diff-fbd4bf6b6dd240d25fb67d5935c58a15eeda17c484051c532372ae95c376737dR95-R107)

### Container and Stack Removal Logic

* Refactored `MainWindowViewModel`'s container and stack removal methods to:
  - Fetch volume information before removal.
  - Prompt the user if named volumes are present.
  - Remove volumes if the user chooses to do so.
  - Refresh the UI accordingly after removal. [[1]](diffhunk://#diff-dc3f08e6b0e922d144c643501a0dd88af732a7e4416311a53edf186437bf34a6L350-R433) [[2]](diffhunk://#diff-dc3f08e6b0e922d144c643501a0dd88af732a7e4416311a53edf186437bf34a6L411-R529) [[3]](diffhunk://#diff-dc3f08e6b0e922d144c643501a0dd88af732a7e4416311a53edf186437bf34a6L421-R573)

### API and Service Contracts

* Updated `IDialogService` to include the new dialog methods and defined the `VolumeRemovalChoice` enum to represent user choices for removal actions.

These changes collectively improve user control over data deletion and enhance the safety and clarity of container and stack removal operations.